### PR TITLE
corrected custom attribute naming conflicts

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasMessageComposer.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasMessageComposer.java
@@ -83,10 +83,10 @@ public class AtlasMessageComposer extends FrameLayout {
     
     public void parseStyle(Context context, AttributeSet attrs, int defStyle) {
         TypedArray ta = context.getTheme().obtainStyledAttributes(attrs, R.styleable.AtlasMessageComposer, R.attr.AtlasMessageComposer, defStyle);
-        this.textColor = ta.getColor(R.styleable.AtlasMessageComposer_textColor, context.getResources().getColor(R.color.atlas_text_black));
-        //this.textSize  = ta.getDimension(R.styleable.AtlasMessageComposer_textSize, context.getResources().getDimension(R.dimen.atlas_text_size_general));
-        this.textStyle = ta.getInt(R.styleable.AtlasMessageComposer_textStyle, Typeface.NORMAL);
-        String typeFaceName = ta.getString(R.styleable.AtlasMessageComposer_textTypeface); 
+        this.textColor = ta.getColor(R.styleable.AtlasMessageComposer_composerTextColor, context.getResources().getColor(R.color.atlas_text_black));
+        //this.textSize  = ta.getDimension(R.styleable.AtlasMessageComposer_composerTextSize, context.getResources().getDimension(R.dimen.atlas_text_size_general));
+        this.textStyle = ta.getInt(R.styleable.AtlasMessageComposer_composerTextStyle, Typeface.NORMAL);
+        String typeFaceName = ta.getString(R.styleable.AtlasMessageComposer_composerTextTypeface); 
         this.typeFace  = typeFaceName != null ? Typeface.create(typeFaceName, textStyle) : null;
         ta.recycle();
     }

--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasTypingIndicator.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasTypingIndicator.java
@@ -111,10 +111,10 @@ public class AtlasTypingIndicator extends FrameLayout implements LayerTypingIndi
     private void parseStyle(Context context, AttributeSet attrs, int defStyle) {
         TypedArray ta = context.getTheme().obtainStyledAttributes(attrs, R.styleable.AtlasTypingIndicator, R.attr.AtlasTypingIndicator, defStyle);
         Resources r = context.getResources();
-        mTextColor = ta.getColor(R.styleable.AtlasTypingIndicator_textColor, r.getColor(R.color.atlas_text_black));
-        mTextStyle = ta.getInt(R.styleable.AtlasTypingIndicator_textStyle, Typeface.NORMAL);
-        mTextTypeface = Typeface.create(ta.getString(R.styleable.AtlasParticipantPicker_inputTextTypeface), mTextStyle);
-        mTextSize = ta.getDimension(R.styleable.AtlasTypingIndicator_textSize, r.getDimension(R.dimen.atlas_text_size_general));
+        mTextColor = ta.getColor(R.styleable.AtlasTypingIndicator_indicatorTextColor, r.getColor(R.color.atlas_text_black));
+        mTextStyle = ta.getInt(R.styleable.AtlasTypingIndicator_indicatorTextStyle, Typeface.NORMAL);
+        mTextTypeface = Typeface.create(ta.getString(R.styleable.AtlasTypingIndicator_indicatorTextTypeface), mTextStyle);
+        mTextSize = ta.getDimension(R.styleable.AtlasTypingIndicator_indicatorTextSize, r.getDimension(R.dimen.atlas_text_size_general));
         ta.recycle();
     }
 

--- a/layer-atlas/src/main/res/values/atlas-styles.xml
+++ b/layer-atlas/src/main/res/values/atlas-styles.xml
@@ -62,10 +62,10 @@
     </declare-styleable>
 
     <declare-styleable name="AtlasMessageComposer">
-        <attr name="textColor"/>
-        <attr name="textSize"/>
-        <attr name="textTypeface"/>
-        <attr name="textStyle"/>
+        <attr name="composerTextColor"/>
+        <attr name="composerTextSize"/>
+        <attr name="composerTextTypeface"/>
+        <attr name="composerTextStyle"/>
     </declare-styleable>
 
     <declare-styleable name="AtlasMessageList">
@@ -100,10 +100,10 @@
     </declare-styleable>
 
     <declare-styleable name="AtlasTypingIndicator">
-        <attr name="textColor"/>
-        <attr name="textSize"/>
-        <attr name="textTypeface"/>
-        <attr name="textStyle"/>
+        <attr name="indicatorTextColor"/>
+        <attr name="indicatorTextSize"/>
+        <attr name="indicatorTextTypeface"/>
+        <attr name="indicatorTextStyle"/>
     </declare-styleable>
 
 
@@ -131,10 +131,10 @@
     </style>
 
     <style name="AtlasMessageComposer">
-        <item name="textColor">@color/atlas_text_black</item>
-        <item name="textSize">@dimen/atlas_text_size_general</item>
-        <item name="textTypeface">normal</item>
-        <item name="textStyle">normal</item>
+        <item name="composerTextColor">@color/atlas_text_black</item>
+        <item name="composerTextSize">@dimen/atlas_text_size_general</item>
+        <item name="composerTextTypeface">normal</item>
+        <item name="composerTextStyle">normal</item>
     </style>
 
     <style name="AtlasMessageList">
@@ -169,10 +169,10 @@
     </style>
 
     <style name="AtlasTypingIndicator">
-        <item name="textColor">@color/atlas_text_black</item>
-        <item name="textSize">@dimen/atlas_text_size_general</item>
-        <item name="textTypeface">normal</item>
-        <item name="textStyle">normal</item>
+        <item name="indicatorTextColor">@color/atlas_text_black</item>
+        <item name="indicatorTextSize">@dimen/atlas_text_size_general</item>
+        <item name="indicatorTextTypeface">normal</item>
+        <item name="indicatorTextStyle">normal</item>
     </style>
 
 
@@ -216,10 +216,10 @@
     <attr name="avatarBackgroundColor" format="color|reference"/>
 
     <!-- message composer -->
-    <attr name="textColor" format="color|reference"/>
-    <attr name="textSize" format="dimension|reference"/>
-    <attr name="textTypeface" format="string|reference"/>
-    <attr name="textStyle">
+    <attr name="composerTextColor" format="color|reference"/>
+    <attr name="composerTextSize" format="dimension|reference"/>
+    <attr name="composerTextTypeface" format="string|reference"/>
+    <attr name="composerTextStyle">
         <flag name="normal" value="0"/>
         <flag name="bold" value="1"/>
         <flag name="italic" value="2"/>
@@ -264,6 +264,16 @@
     <attr name="chipTextColor" format="color|reference"/>
     <attr name="chipTextTypeface" format="string|reference"/>
     <attr name="chipTextStyle">
+        <flag name="normal" value="0"/>
+        <flag name="bold" value="1"/>
+        <flag name="italic" value="2"/>
+    </attr>
+
+    <!-- typing indicator -->
+    <attr name="indicatorTextColor" format="color|reference"/>
+    <attr name="indicatorTextSize" format="dimension|reference"/>
+    <attr name="indicatorTextTypeface" format="string|reference"/>
+    <attr name="indicatorTextStyle">
         <flag name="normal" value="0"/>
         <flag name="bold" value="1"/>
         <flag name="italic" value="2"/>


### PR DESCRIPTION
A user reported the following error:

```
Error:(86, 49) error: cannot find symbol variable AtlasMessageComposer_textColor
Error:(114, 45) error: cannot find symbol variable AtlasTypingIndicator_textColor
Error:Execution failed for task ':layer-atlas:compileReleaseJava'.
```

We corrected a similar issue before when an attribute name conflicted with another attribute defined in a later version of Android.  The solution is to rename `textSize` and `textColor` to unique names.

A styling bug was also fixed in `AtlasTypingIndicator` which was keying its `typeFace` off the `ParticipantPicker's` style rather than its own.