### PR TITLE
Change bloating default colors + few more improvements

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsList.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsList.java
@@ -37,6 +37,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Handler;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -212,6 +213,7 @@ public class AtlasConversationsList extends FrameLayout implements LayerChangeEv
                     avatarImgView.setImageBitmap(avatarBmp);
                 }
                 Canvas canvas = new Canvas(avatarBmp);
+                canvas.drawColor(0, Mode.CLEAR);
                 canvas.drawColor(avatarBackgroundColor);
                 if (allButMe.size() < 2) {
                     String conterpartyUserId = allButMe.get(0);
@@ -409,7 +411,22 @@ public class AtlasConversationsList extends FrameLayout implements LayerChangeEv
             });
         }
     }
-    
+
+    private volatile boolean refreshScheduled = false;
+
+    public void requestRefresh() {
+        if (refreshScheduled) return;
+        refreshScheduled = true;
+        conversationsList.post(INVALIDATE_VIEW);
+    }
+
+    private final Runnable INVALIDATE_VIEW = new Runnable() {
+        public void run() {
+            conversationsList.invalidateViews();
+            refreshScheduled = false;
+        }
+    };
+
     public void setQuery(Query<Conversation> query) {
         if (debug) Log.w(TAG, "setQuery() query: " + query);
         // check

--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasMessagesList.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasMessagesList.java
@@ -368,7 +368,7 @@ public class AtlasMessagesList extends FrameLayout implements LayerChangeEventLi
 
     public void parseStyle(Context context, AttributeSet attrs, int defStyle) {
         TypedArray ta = context.getTheme().obtainStyledAttributes(attrs, R.styleable.AtlasMessageList, R.attr.AtlasMessageList, defStyle);
-        this.myTextColor = ta.getColor(R.styleable.AtlasMessageList_myTextColor, context.getResources().getColor(R.color.atlas_text_black));
+        this.myTextColor = ta.getColor(R.styleable.AtlasMessageList_myTextColor, context.getResources().getColor(R.color.atlas_text_white));
         this.myTextStyle = ta.getInt(R.styleable.AtlasMessageList_myTextStyle, Typeface.NORMAL);
         String myTextTypefaceName = ta.getString(R.styleable.AtlasMessageList_myTextTypeface); 
         this.myTextTypeface  = myTextTypefaceName != null ? Typeface.create(myTextTypefaceName, myTextStyle) : null;

--- a/layer-atlas/src/main/res/layout/atlas_message_composer.xml
+++ b/layer-atlas/src/main/res/layout/atlas_message_composer.xml
@@ -19,21 +19,30 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal" >
 
-    <TextView 
-        android:id="@+id/atlas_message_composer_upload"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:layout_gravity="bottom"
-        android:gravity="center"
-        android:text="+"
-        android:visibility="gone"
-        />
-    
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="12dp">
+
+        <TextView
+            android:id="@+id/atlas_message_composer_upload"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="bottom"
+            android:gravity="center"
+            android:text="+"
+            android:textColor="@color/atlas_text_gray"
+            android:visibility="gone"
+            />
+
+    </FrameLayout>
+
     <EditText
         android:id="@+id/atlas_message_composer_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:layout_gravity="center_vertical"
         android:maxLines="4"
         android:textSize="@dimen/atlas_text_size_general"
         android:background="@drawable/atlas_ctl_edit_text"

--- a/layer-atlas/src/main/res/layout/atlas_participants_picker.xml
+++ b/layer-atlas/src/main/res/layout/atlas_participants_picker.xml
@@ -23,6 +23,8 @@
 		android:orientation="horizontal"
 		android:layout_width="match_parent"
 		android:layout_height="48dp"
+        android:layout_marginLeft="12dp"
+        android:layout_marginRight="12dp"
 		android:background="@color/atlas_view_participant_picker_text_background"
 		>
 		
@@ -99,6 +101,8 @@
 			android:layout_height="48dp"
 			android:gravity="center"
 			android:text="+"
+            android:textColor="@color/atlas_text_gray"
+            android:visibility="gone"
 			/>
 		
 	</LinearLayout>

--- a/layer-atlas/src/main/res/layout/atlas_view_conversations_list_convert.xml
+++ b/layer-atlas/src/main/res/layout/atlas_view_conversations_list_convert.xml
@@ -97,7 +97,7 @@
 		<!-- delimiter -->
         <View 
         	android:layout_width="match_parent" 
-        	android:layout_height="1dp"
+        	android:layout_height="1px"
         	android:layout_gravity="bottom" 
         	android:background="@color/atlas_delimeter_gray"
         	/>


### PR DESCRIPTION
Improvements:
- conversations: avatar icons turns from light gray to dark gray and finally to black (clean canvas before draw). nice separator
- messages: white text on blue background instead of black
- composer: left margin for text
- picker: left margin for text and hidden "+" button (doesn't work. cannot find implementation?)