### PR TITLE
Remove CAMERA permission from CameraSender

### DIFF
--- a/layer-atlas/build.gradle
+++ b/layer-atlas/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     // Layer SDK
-    compile('com.layer.sdk:layer-sdk:0.19.4') {
+    compile('com.layer.sdk:layer-sdk:0.19.5') {
         exclude group: 'com.google.android.gms', module: 'play-services-gcm'
     }
     compile 'org.slf4j:slf4j-nop:1.7.2'

--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/text/TextCellFactory.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/text/TextCellFactory.java
@@ -17,6 +17,7 @@ import com.layer.atlas.util.Util;
 import com.layer.sdk.LayerClient;
 import com.layer.sdk.messaging.Actor;
 import com.layer.sdk.messaging.Message;
+import com.layer.sdk.messaging.MessagePart;
 
 public class TextCellFactory extends AtlasCellFactory<TextCellFactory.CellHolder, TextCellFactory.TextInfo> implements View.OnLongClickListener {
     public final static String MIME_TYPE = "text/plain";
@@ -30,7 +31,9 @@ public class TextCellFactory extends AtlasCellFactory<TextCellFactory.CellHolder
     }
 
     public static String getMessagePreview(Context context, Message message) {
-        return new String(message.getMessageParts().get(0).getData());
+        MessagePart part = message.getMessageParts().get(0);
+        // For large text content, the MessagePart may not be downloaded yet.
+        return part.isContentReady() ? new String(part.getData()) : "";
     }
 
     @Override
@@ -42,7 +45,7 @@ public class TextCellFactory extends AtlasCellFactory<TextCellFactory.CellHolder
     public CellHolder createCellHolder(ViewGroup cellView, boolean isMe, LayoutInflater layoutInflater) {
         View v = layoutInflater.inflate(R.layout.atlas_message_item_cell_text, cellView, true);
         v.setBackgroundResource(isMe ? R.drawable.atlas_message_item_cell_me : R.drawable.atlas_message_item_cell_them);
-        ((GradientDrawable) v.getBackground()).setColor(isMe ? mMessageStyle.getMyBubbleColor(): mMessageStyle.getOtherBubbleColor());
+        ((GradientDrawable) v.getBackground()).setColor(isMe ? mMessageStyle.getMyBubbleColor() : mMessageStyle.getOtherBubbleColor());
 
         TextView t = (TextView) v.findViewById(R.id.cell_text);
         t.setTextSize(TypedValue.COMPLEX_UNIT_PX, isMe ? mMessageStyle.getMyTextSize() : mMessageStyle.getOtherTextSize());
@@ -54,7 +57,8 @@ public class TextCellFactory extends AtlasCellFactory<TextCellFactory.CellHolder
 
     @Override
     public TextInfo parseContent(LayerClient layerClient, ParticipantProvider participantProvider, Message message) {
-        String text = new String(message.getMessageParts().get(0).getData());
+        MessagePart part = message.getMessageParts().get(0);
+        String text = part.isContentReady() ? new String(part.getData()) : "";
         String name;
         Actor sender = message.getSender();
         if (sender.getName() != null) {

--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/CameraSender.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/CameraSender.java
@@ -1,9 +1,7 @@
 package com.layer.atlas.messagetypes.threepartimage;
 
-import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
@@ -19,17 +17,17 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static android.support.v4.app.ActivityCompat.requestPermissions;
-import static android.support.v4.content.ContextCompat.checkSelfPermission;
-
 /**
- * CameraSender creates a ThreePartImage from the device's camera.  Requires
- * `Manifest.permission.CAMERA` to take photos.
+ * CameraSender creates a ThreePartImage from the device's camera.
+ *
+ * Note: If your AndroidManifest declares that it uses the CAMERA permission, then CameraSender will
+ * require that the CAMERA permission is also granted.  If your AndroidManifest does not declare
+ * that it uses the CAMERA permission, then CameraSender will not require the CAMERA permission to
+ * be granted. See http://developer.android.com/reference/android/provider/MediaStore.html#ACTION_IMAGE_CAPTURE
+ * for details.
  */
 public class CameraSender extends AttachmentSender {
-    private static final String PERMISSION = Manifest.permission.CAMERA;
     public static final int ACTIVITY_REQUEST_CODE = 20;
-    public static final int PERMISSION_REQUEST_CODE = 21;
 
     private WeakReference<Activity> mActivity = new WeakReference<Activity>(null);
 
@@ -55,26 +53,10 @@ public class CameraSender extends AttachmentSender {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        if (requestCode != PERMISSION_REQUEST_CODE) return;
-        if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-            if (Log.isLoggable(Log.VERBOSE)) Log.v("Camera permission denied");
-            return;
-        }
-        Activity activity = mActivity.get();
-        if (activity == null) return;
-        startCameraIntent(activity);
-    }
-
-    @Override
     public boolean requestSend() {
         Activity activity = mActivity.get();
         if (activity == null) return false;
         if (Log.isLoggable(Log.VERBOSE)) Log.v("Sending camera image");
-        if (checkSelfPermission(activity, PERMISSION) != PackageManager.PERMISSION_GRANTED) {
-            requestPermissions(activity, new String[]{PERMISSION}, PERMISSION_REQUEST_CODE);
-            return true;
-        }
         startCameraIntent(activity);
         return true;
     }


### PR DESCRIPTION
1. Bumped to LayerSDK `0.19.5`.
2. Removed CAMERA permission from CameraSender.
3. Fixed `TextCellFactory` handling of large text content when content is not yet ready.

#50