### PR TITLE
Reycle sampled bitmap after preview bitmap is compressed

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/ThreePartImageUtils.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/messagetypes/threepartimage/ThreePartImageUtils.java
@@ -161,13 +161,13 @@ public class ThreePartImageUtils {
         // Create preview
         Bitmap sampledBitmap = BitmapFactory.decodeFile(file.getAbsolutePath(), previewOptions);
         Bitmap previewBitmap = Bitmap.createScaledBitmap(sampledBitmap, previewDim[0], previewDim[1], true);
-        sampledBitmap.recycle();
         File temp = new File(context.getCacheDir(), ThreePartImageUtils.class.getSimpleName() + "." + System.nanoTime() + ".jpg");
         FileOutputStream previewStream = new FileOutputStream(temp);
         if (Log.isLoggable(Log.VERBOSE)) {
             Log.v("Compressing preview to '" + temp.getAbsolutePath() + "'");
         }
         previewBitmap.compress(Bitmap.CompressFormat.JPEG, PREVIEW_COMPRESSION_QUALITY, previewStream);
+        sampledBitmap.recycle();
         previewBitmap.recycle();
         previewStream.close();
 


### PR DESCRIPTION
If the sampled bitmap is small enough, the preview bitmap will reference the original rather than creating a new scaled bitmap. This results in a "can't compress a recycled bitmap" error.