### PR TITLE
Feature/optional oneonone avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.layer.atlas:layer-atlas:0.3.0'
+    compile 'com.layer.atlas:layer-atlas:0.4.2'
 }
 ```
 

--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasMessagesRecyclerView.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasMessagesRecyclerView.java
@@ -196,6 +196,27 @@ public class AtlasMessagesRecyclerView extends RecyclerView {
     }
 
     /**
+     * Convenience pass-through to this list's AtlasMessagesAdapter.
+     *
+     * @see AtlasMessagesAdapter#getShouldShowAvatarInOneOnOneConversations()
+     */
+
+    public boolean getShouldShowAvatarInOneOnOneConversations() {
+        return mAdapter.getShouldShowAvatarInOneOnOneConversations();
+    }
+
+    /**
+     * Convenience pass-through to this list's AtlasMessagesAdapter.
+     *
+     * @see AtlasMessagesAdapter#setShouldShowAvatarInOneOnOneConversations(boolean)
+     */
+
+    public void setShouldShowAvatarInOneOnOneConversations(boolean shouldShowAvatarInOneOnOneConversations) {
+        mAdapter.setShouldShowAvatarInOneOnOneConversations(shouldShowAvatarInOneOnOneConversations);
+    }
+
+
+    /**
      * Scrolls if the user is at the end
      */
     private void autoScroll() {

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
@@ -470,8 +470,8 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
         return mShouldShowAvatarInOneOnOneConversations;
     }
 
-    public void setShouldShowAvatarInOneOnOneConversations(boolean mShouldShowAvatarInOneOnOneConversations) {
-        this.mShouldShowAvatarInOneOnOneConversations = mShouldShowAvatarInOneOnOneConversations;
+    public void setShouldShowAvatarInOneOnOneConversations(boolean shouldShowAvatarInOneOnOneConversations) {
+        this.mShouldShowAvatarInOneOnOneConversations = shouldShowAvatarInOneOnOneConversations;
     }
 
 

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
@@ -180,10 +180,19 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
         return mFooterView;
     }
 
+    /**
+     * @return If the Avatar for the other participant in a one on one conversation  will be shown
+     * or not
+     */
     public boolean getShouldShowAvatarInOneOnOneConversations() {
         return mShouldShowAvatarInOneOnOneConversations;
     }
 
+    /**
+     * @param shouldShowAvatarInOneOnOneConversations Whether the Avatar for the other participant
+     *                                                in a one on one conversation should be shown
+     *                                                or not
+     */
     public void setShouldShowAvatarInOneOnOneConversations(boolean shouldShowAvatarInOneOnOneConversations) {
         this.mShouldShowAvatarInOneOnOneConversations = shouldShowAvatarInOneOnOneConversations;
     }

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
@@ -43,14 +43,14 @@ import java.util.Set;
  * it can render, can create new View hierarchies for its Message types, and can render (bind)
  * Message data with its created View hierarchies.  Typically, CellFactories are segregated by
  * MessagePart MIME types (e.g. "text/plain", "image/jpeg", and "application/vnd.geo+json").
- *
+ * <p>
  * Under the hood, the AtlasMessagesAdapter is a RecyclerView.Adapter, which automatically recycles
  * its list items within view-type "buckets".  Each registered CellFactory actually creates two such
  * view-types: one for cells sent by the authenticated user, and another for cells sent by remote
  * actors.  This allows the AtlasMessagesAdapter to efficiently render images sent by the current
  * user aligned on the left, and images sent by others aligned on the right, for example.  In case
  * this sent-by distinction is of value when rendering cells, it provided as the `isMe` argument.
- *
+ * <p>
  * When rendering Messages, the AtlasMessagesAdapter first determines which CellFactory to handle
  * the Message with calling CellFactory.isBindable() on each of its registered CellFactories. The
  * first CellFactory to return `true` is used for that Message.  Then, the adapter checks for
@@ -94,6 +94,8 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
 
     private RecyclerView mRecyclerView;
     private boolean mReadReceiptsEnabled = true;
+
+    protected boolean mShouldShowAvatarInOneOnOneConversations;
 
     public AtlasMessagesAdapter(Context context, LayerClient layerClient, Picasso picasso) {
         mLayerClient = layerClient;
@@ -351,12 +353,16 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
 
             // Avatars
             if (oneOnOne) {
-                // Not in one-on-one conversations
-                viewHolder.mAvatar.setVisibility(View.GONE);
+                if (mShouldShowAvatarInOneOnOneConversations) {
+                    viewHolder.mAvatar.setVisibility(View.VISIBLE);
+                    viewHolder.mAvatar.setParticipants(message.getSender());
+
+                } else {
+                    viewHolder.mAvatar.setVisibility(View.GONE);
+                }
             } else if (cluster.mClusterWithNext == null || cluster.mClusterWithNext != ClusterType.LESS_THAN_MINUTE) {
                 // Last message in cluster
-                viewHolder.mAvatar.setVisibility(View.VISIBLE);
-                viewHolder.mAvatar.setParticipants(message.getSender());
+
 
                 // Add the position to the positions map for Identity updates
                 mIdentityEventListener.addIdentityPosition(position, Collections.singleton(message.getSender()));
@@ -454,6 +460,18 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
     public Message getItem(RecyclerView.ViewHolder viewHolder) {
         if (!(viewHolder instanceof CellViewHolder)) return null;
         return ((CellViewHolder) viewHolder).mMessage;
+    }
+
+    //==============================================================================================
+    // Getters and setters
+    //==============================================================================================
+
+    public boolean getShouldShowAvatarInOneOnOneConversations() {
+        return mShouldShowAvatarInOneOnOneConversations;
+    }
+
+    public void setShouldShowAvatarInOneOnOneConversations(boolean mShouldShowAvatarInOneOnOneConversations) {
+        this.mShouldShowAvatarInOneOnOneConversations = mShouldShowAvatarInOneOnOneConversations;
     }
 
 

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasMessagesAdapter.java
@@ -180,6 +180,14 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
         return mFooterView;
     }
 
+    public boolean getShouldShowAvatarInOneOnOneConversations() {
+        return mShouldShowAvatarInOneOnOneConversations;
+    }
+
+    public void setShouldShowAvatarInOneOnOneConversations(boolean shouldShowAvatarInOneOnOneConversations) {
+        this.mShouldShowAvatarInOneOnOneConversations = shouldShowAvatarInOneOnOneConversations;
+    }
+
     /**
      * Set whether or not the conversation supports read receipts. This determines if the read
      * receipts should be shown in the view holders.
@@ -461,19 +469,6 @@ public class AtlasMessagesAdapter extends RecyclerView.Adapter<AtlasMessagesAdap
         if (!(viewHolder instanceof CellViewHolder)) return null;
         return ((CellViewHolder) viewHolder).mMessage;
     }
-
-    //==============================================================================================
-    // Getters and setters
-    //==============================================================================================
-
-    public boolean getShouldShowAvatarInOneOnOneConversations() {
-        return mShouldShowAvatarInOneOnOneConversations;
-    }
-
-    public void setShouldShowAvatarInOneOnOneConversations(boolean shouldShowAvatarInOneOnOneConversations) {
-        this.mShouldShowAvatarInOneOnOneConversations = shouldShowAvatarInOneOnOneConversations;
-    }
-
 
     //==============================================================================================
     // Clustering


### PR DESCRIPTION
Currently the `AtlasMessagesAdapter` hides the avatar for the other participant if the conversation has just 2 participants, i.e. is a 1:1 conversation. 

The default is still to hide the avatar, but there is now a method available on `AtlasMessagesRecyclerView` that allows this behavior to be optional.