### PR TITLE
Added functionality to select a chat item in the conversationsAdapter…

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsRecyclerView.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsRecyclerView.java
@@ -65,18 +65,17 @@ public class AtlasConversationsRecyclerView extends RecyclerView {
 
         mAdapter = new AtlasConversationsAdapter(getContext(), layerClient, picasso);
         mAdapter.setStyle(conversationStyle);
-        mAdapter.setRecyclerView(this);
         super.setAdapter(mAdapter);
         refresh();
 
         return this;
     }
-    /**
-     * programmatically clicks on the first item (0 index) in the recyclerView.
-     */
-    public void defaultSelectFirstItem() {
-        mAdapter.defaultSelectFirstItem();
+
+    @Override
+    public AtlasConversationsAdapter getAdapter() {
+        return mAdapter;
     }
+
 
     @Override
     public void setAdapter(Adapter adapter) {

--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsRecyclerView.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsRecyclerView.java
@@ -70,6 +70,12 @@ public class AtlasConversationsRecyclerView extends RecyclerView {
 
         return this;
     }
+    /**
+     * programmatically clicks on the first item (0 index) in the recyclerView.
+     */
+    public void defaultSelectFirstItem() {
+        mAdapter.defaultSelectFirstItem();
+    }
 
     @Override
     public void setAdapter(Adapter adapter) {

--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsRecyclerView.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasConversationsRecyclerView.java
@@ -65,6 +65,7 @@ public class AtlasConversationsRecyclerView extends RecyclerView {
 
         mAdapter = new AtlasConversationsAdapter(getContext(), layerClient, picasso);
         mAdapter.setStyle(conversationStyle);
+        mAdapter.setRecyclerView(this);
         super.setAdapter(mAdapter);
         refresh();
 

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
@@ -104,11 +104,11 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
     }
 
     /**
-     * Updates the selected position marker to the Position passed in the params.  Notifs adapter that the old item that was selected has changed, and that the new item that is selected has changed.
+     * Updates the mSelectedPosition marker to the Position passed in the params.  Notifies adapter about the change.
      * @param position the position of the currently selected item.
      */
     private void updateSelectedItem(int position) {
-//        notifyItemChanged(mSelectedPosition);
+        notifyItemChanged(mSelectedPosition);
         mSelectedPosition = position;
         notifyItemChanged(mSelectedPosition);
     }

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.layer.atlas.AtlasAvatar;
+import com.layer.atlas.AtlasConversationsRecyclerView;
 import com.layer.atlas.R;
 import com.layer.atlas.messagetypes.AtlasCellFactory;
 import com.layer.atlas.messagetypes.generic.GenericCellFactory;
@@ -53,6 +54,8 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
 
     protected Set<AtlasCellFactory> mCellFactories;
     private Set<AtlasCellFactory> mDefaultCellFactories;
+
+    protected AtlasConversationsRecyclerView mRecyclerView;
 
     /**
      * The position of the selected item.  It is defaulted to -1 as we do not want to select any items by default.
@@ -132,6 +135,18 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
      */
     public void onDestroy() {
         mLayerClient.unregisterEventListener(mIdentityEventListener);
+    }
+
+    /**
+     * programmatically clicks on the first item (0 index) in the recyclerView.
+     */
+    public void defaultSelectFirstItem() {
+        ViewHolder tempView = (ViewHolder) mRecyclerView.findViewHolderForAdapterPosition(0);
+        tempView.itemView.performClick();
+    }
+
+    public void setRecyclerView(AtlasConversationsRecyclerView recyclerView) {
+        this.mRecyclerView = recyclerView;
     }
 
     //==============================================================================================
@@ -302,7 +317,6 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
     @Override
     public void onQueryItemChanged(RecyclerViewController controller, int position) {
         notifyItemChanged(position);
-
         if (Log.isPerfLoggable()) {
             Log.perf("Conversations adapter - onQueryItemChanged. Position: " + position);
         }
@@ -321,10 +335,8 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
     public void onQueryItemInserted(RecyclerViewController controller, int position) {
         syncInitialMessages(position, 1);
         notifyItemInserted(position);
-        if (mSelectedPosition == position) {
+        if(mSelectedPosition >= position) {
             updateSelectedItem(mSelectedPosition + 1);
-        } else if(mSelectedPosition > position) {
-            updateSelectedItem(mSelectedPosition - 1);
         }
         if (Log.isPerfLoggable()) {
             Log.perf("Conversations adapter - onQueryItemInserted. Position: " + position);

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
@@ -300,6 +300,14 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
         return mDefaultCellFactories;
     }
 
+    public int getSelectedPosition() {
+        return mSelectedPosition;
+    }
+
+    public void setSelectedPosition(int position) {
+        mSelectedPosition = position;
+    }
+
     //==============================================================================================
     // UI update callbacks
     //==============================================================================================

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
@@ -55,8 +55,6 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
     protected Set<AtlasCellFactory> mCellFactories;
     private Set<AtlasCellFactory> mDefaultCellFactories;
 
-    protected AtlasConversationsRecyclerView mRecyclerView;
-
     /**
      * The position of the selected item.  It is defaulted to -1 as we do not want to select any items by default.
      */
@@ -83,9 +81,9 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
         mTimeFormat = android.text.format.DateFormat.getTimeFormat(context);
         mViewHolderClickListener = new ViewHolder.OnClickListener() {
             @Override
-            public void onClick(ViewHolder viewHolder, int position) {
+            public void onClick(ViewHolder viewHolder) {
                 if (mConversationClickListener == null) return;
-                updateSelectedItem(position);
+                updateSelectedItem(viewHolder.getAdapterPosition());
                 if (Log.isPerfLoggable()) {
                     Log.perf("Conversation ViewHolder onClick");
                 }
@@ -106,11 +104,11 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
     }
 
     /**
-     * Updates the mSelectedPosition marker to the Position passed in the params.  Notifs adapter that the old item that was selected has changed, and that the new item that is selected has changed.
+     * Updates the selected position marker to the Position passed in the params.  Notifs adapter that the old item that was selected has changed, and that the new item that is selected has changed.
      * @param position the position of the currently selected item.
      */
     private void updateSelectedItem(int position) {
-        notifyItemChanged(mSelectedPosition);
+//        notifyItemChanged(mSelectedPosition);
         mSelectedPosition = position;
         notifyItemChanged(mSelectedPosition);
     }
@@ -138,15 +136,10 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
     }
 
     /**
-     * programmatically clicks on the first item (0 index) in the recyclerView.
+     * Programmatically selects the first item (0 index) in the recyclerView.
      */
     public void defaultSelectFirstItem() {
-        ViewHolder tempView = (ViewHolder) mRecyclerView.findViewHolderForAdapterPosition(0);
-        tempView.itemView.performClick();
-    }
-
-    public void setRecyclerView(AtlasConversationsRecyclerView recyclerView) {
-        this.mRecyclerView = recyclerView;
+        updateSelectedItem(0);
     }
 
     //==============================================================================================
@@ -459,7 +452,7 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
         @Override
         public void onClick(View v) {
             if (mClickListener == null) return;
-            mClickListener.onClick(this, getLayoutPosition());
+            mClickListener.onClick(this);
         }
 
         @Override
@@ -469,7 +462,7 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
         }
 
         interface OnClickListener {
-            void onClick(ViewHolder viewHolder, int position);
+            void onClick(ViewHolder viewHolder);
 
             boolean onLongClick(ViewHolder viewHolder);
         }

--- a/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/adapters/AtlasConversationsAdapter.java
@@ -108,8 +108,9 @@ public class AtlasConversationsAdapter extends RecyclerView.Adapter<AtlasConvers
      * @param position the position of the currently selected item.
      */
     private void updateSelectedItem(int position) {
-        notifyItemChanged(mSelectedPosition);
+        int oldSelectedPosition = mSelectedPosition;
         mSelectedPosition = position;
+        notifyItemChanged(oldSelectedPosition);
         notifyItemChanged(mSelectedPosition);
     }
 

--- a/layer-atlas/src/main/res/drawable/atlas_swipeable_item_foreground_selector.xml
+++ b/layer-atlas/src/main/res/drawable/atlas_swipeable_item_foreground_selector.xml
@@ -3,4 +3,6 @@
           xmlns:atlas="http://schemas.android.com/apk/res-auto">
     <item android:drawable="@color/atlas_item_swiping" android:state_pressed="true"/>
     <item android:drawable="@color/atlas_item_swiping" atlas:state_swiping="true"/>
+    <item android:state_activated="true" android:drawable="@color/atlas_item_selected" />
+    <item android:drawable="@android:color/transparent"/>
 </selector>


### PR DESCRIPTION
In AtlasConversationAdapter added code that allows sets the activated to true when a user clicks on a recycler view item the adapter tracks the selected position so that the recycler view gets deactivated when it is used for a new item, and activated when the selected item gets put back in to a recycler view.  

Added a default selection method in AtlasConversationsRecyclerView and the AtlasConversationAdapter so that we can programatically select the first item (index 0)in the adapter  if needed. 