### PR TITLE
Bug/Send button enabled on empty message

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasMessageComposer.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasMessageComposer.java
@@ -123,7 +123,9 @@ public class AtlasMessageComposer extends FrameLayout {
             @Override
             public void afterTextChanged(Editable s) {
                 if (mConversation == null || mConversation.isDeleted()) return;
-                if (s.length() > 0) {
+
+                String message = s.toString().trim();
+                if (message.length() > 0) {
                     mSendButton.setEnabled(isEnabled());
                     mConversation.send(LayerTypingIndicatorListener.TypingIndicator.STARTED);
                 } else {


### PR DESCRIPTION
Do not enable send button if trying to send an empty message. Trim whitespace before and after message.