### PR TITLE
Added a color state list to the ‘send’ button to…

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasMessageComposer.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasMessageComposer.java
@@ -302,6 +302,9 @@ public class AtlasMessageComposer extends FrameLayout {
         Drawable d = DrawableCompat.wrap(mAttachButton.getDrawable().mutate());
         DrawableCompat.setTintList(d, list);
         mAttachButton.setImageDrawable(d);
+
+        ColorStateList sendButtonColorList = getResources().getColorStateList(R.color.atlas_message_composer_send_button);
+        mSendButton.setTextColor(sendButtonColorList);
     }
 
     private void applyTypeface() {

--- a/layer-atlas/src/main/res/color/atlas_message_composer_send_button.xml
+++ b/layer-atlas/src/main/res/color/atlas_message_composer_send_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/atlas_button_text_disabled" android:state_enabled="false"/>
+    <item android:color="@color/atlas_button_text_pressed" android:state_pressed="true"/>
+    <item android:color="@color/atlas_button_text_enabled"/>
+</selector>


### PR DESCRIPTION
have different appearances for the button in it’s disabled, pressed and enabled states.


The purpose of this change is to make it obvious when the user can and cannot press the 'send' button, as well as to make the UI feel more responsive, native and to follow material design for the button pressed state (ripple animation effect).

This was modelled after the 'attach' button.