### PR TITLE
Expose more avatar customization points.

### DIFF
--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasAvatar.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasAvatar.java
@@ -20,6 +20,7 @@ import com.layer.sdk.messaging.Identity;
 import com.layer.sdk.messaging.Presence;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
+import com.squareup.picasso.Transformation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,9 +41,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class AtlasAvatar extends View {
     public static final String TAG = AtlasAvatar.class.getSimpleName();
 
-    private final static CircleTransform SINGLE_TRANSFORM = new CircleTransform(TAG + ".single");
-    private final static CircleTransform MULTI_TRANSFORM = new CircleTransform(TAG + ".multi");
-
     private static final Paint PAINT_TRANSPARENT = new Paint();
     private static final Paint PAINT_BITMAP = new Paint();
 
@@ -51,6 +49,8 @@ public class AtlasAvatar extends View {
     private final Paint mPaintBackground = new Paint();
     private final Paint mPresencePaint = new Paint();
     private final Paint mBackgroundPaint = new Paint();
+	private Transformation mSingleTransform;
+	private Transformation mMultiTransform;
 
     private boolean mShouldShowPresence = true;
 
@@ -123,6 +123,8 @@ public class AtlasAvatar extends View {
         mPaintBorder.setColor(avatarStyle.getAvatarBorderColor());
         mPaintInitials.setColor(avatarStyle.getAvatarTextColor());
         mPaintInitials.setTypeface(avatarStyle.getAvatarTextTypeface());
+		mSingleTransform = avatarStyle.getSingleTransform();
+		mMultiTransform = avatarStyle.getMultiTransform();
         return this;
     }
 
@@ -294,10 +296,21 @@ public class AtlasAvatar extends View {
                     if (targetUrl != null && targetUrl.trim().length() == 0) {
                         targetUrl = null;
                     }
+
+					Transformation singleTransform = mSingleTransform;
+					Transformation multiTransform = mMultiTransform;
+					if (singleTransform == null) {
+						singleTransform = new CircleTransform(TAG + ".single");
+					}
+					if (multiTransform == null) {
+						multiTransform = new CircleTransform(TAG + ".multi");
+					}
+					Transformation transformation = (avatarCount > 1) ? multiTransform : singleTransform;
+
                     mPicasso.load(targetUrl)
                             .tag(AtlasAvatar.TAG).noPlaceholder().noFade()
                             .centerCrop().resize(size, size)
-                            .transform((avatarCount > 1) ? MULTI_TRANSFORM : SINGLE_TRANSFORM)
+							.transform(transformation)
                             .into(imageTarget);
                 }
                 mPendingLoads.clear();

--- a/layer-atlas/src/main/java/com/layer/atlas/AtlasAvatar.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/AtlasAvatar.java
@@ -49,8 +49,8 @@ public class AtlasAvatar extends View {
     private final Paint mPaintBackground = new Paint();
     private final Paint mPresencePaint = new Paint();
     private final Paint mBackgroundPaint = new Paint();
-	private Transformation mSingleTransform;
-	private Transformation mMultiTransform;
+    private Transformation mSingleTransform;
+    private Transformation mMultiTransform;
 
     private boolean mShouldShowPresence = true;
 
@@ -123,8 +123,8 @@ public class AtlasAvatar extends View {
         mPaintBorder.setColor(avatarStyle.getAvatarBorderColor());
         mPaintInitials.setColor(avatarStyle.getAvatarTextColor());
         mPaintInitials.setTypeface(avatarStyle.getAvatarTextTypeface());
-		mSingleTransform = avatarStyle.getSingleTransform();
-		mMultiTransform = avatarStyle.getMultiTransform();
+        mSingleTransform = avatarStyle.getSingleTransform();
+        mMultiTransform = avatarStyle.getMultiTransform();
         return this;
     }
 
@@ -297,20 +297,20 @@ public class AtlasAvatar extends View {
                         targetUrl = null;
                     }
 
-					Transformation singleTransform = mSingleTransform;
-					Transformation multiTransform = mMultiTransform;
-					if (singleTransform == null) {
-						singleTransform = new CircleTransform(TAG + ".single");
-					}
-					if (multiTransform == null) {
-						multiTransform = new CircleTransform(TAG + ".multi");
-					}
-					Transformation transformation = (avatarCount > 1) ? multiTransform : singleTransform;
+                    Transformation singleTransform = mSingleTransform;
+                    Transformation multiTransform = mMultiTransform;
+                    if (singleTransform == null) {
+                    	singleTransform = new CircleTransform(TAG + ".single");
+                    }
+                    if (multiTransform == null) {
+                    	multiTransform = new CircleTransform(TAG + ".multi");
+                    }
+                    Transformation transformation = (avatarCount > 1) ? multiTransform : singleTransform;
 
                     mPicasso.load(targetUrl)
                             .tag(AtlasAvatar.TAG).noPlaceholder().noFade()
                             .centerCrop().resize(size, size)
-							.transform(transformation)
+                            .transform(transformation)
                             .into(imageTarget);
                 }
                 mPendingLoads.clear();

--- a/layer-atlas/src/main/java/com/layer/atlas/util/AvatarStyle.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/AvatarStyle.java
@@ -1,6 +1,11 @@
 package com.layer.atlas.util;
 
+import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Typeface;
+
+import com.layer.atlas.R;
+import com.squareup.picasso.Transformation;
 
 public final class AvatarStyle {
 
@@ -8,17 +13,54 @@ public final class AvatarStyle {
     private int mAvatarBorderColor;
     private int mAvatarTextColor;
     private Typeface mAvatarTextTypeface;
+	private Transformation mSingleTransform;
+	private Transformation mMultiTransform;
 
     private AvatarStyle(Builder builder) {
         mAvatarBackgroundColor = builder.avatarBackgroundColor;
         mAvatarTextColor = builder.avatarTextColor;
         mAvatarTextTypeface = builder.avatarTextTypeface;
         mAvatarBorderColor = builder.avatarBorderColor;
+		mSingleTransform = builder.singleTransform;
+		mMultiTransform = builder.multiTransform;
     }
+
+    public static AvatarStyle getDefaultStyle(Context context) {
+		TypedArray ta = context.getTheme().obtainStyledAttributes(null, R.styleable.AtlasConversationsRecyclerView,
+		R.attr.AtlasConversationsRecyclerView, 0);
+		AvatarStyle.Builder avatarStyleBuilder = new AvatarStyle.Builder();
+		avatarStyleBuilder.avatarTextColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarTextColor,
+		context.getResources().getColor(R.color.atlas_avatar_text)));
+		avatarStyleBuilder.avatarBackgroundColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarBackgroundColor,
+		context.getResources().getColor(R.color.atlas_avatar_background)));
+		avatarStyleBuilder.avatarBorderColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarBorderColor,
+		context.getResources().getColor(R.color.atlas_avatar_border)));
+		return avatarStyleBuilder.build();
+	}
 
     public void setAvatarTextTypeface(Typeface avatarTextTypeface) {
         this.mAvatarTextTypeface = avatarTextTypeface;
     }
+
+	public void setAvatarBackgroundColor(int color) {
+		this.mAvatarBackgroundColor = color;
+	}
+
+	public void setAvatarTextColor(int color) {
+		this.mAvatarTextColor = color;
+	}
+
+	public void setAvatarBorderColor(int color) {
+		this.mAvatarBorderColor = color;
+	}
+
+	public void setSingleTransform(Transformation transform) {
+		this.mSingleTransform = transform;
+	}
+
+	public void setMultiTransform(Transformation transform) {
+		this.mMultiTransform = transform;
+	}
 
     public int getAvatarBackgroundColor() {
         return mAvatarBackgroundColor;
@@ -36,11 +78,21 @@ public final class AvatarStyle {
         return mAvatarBorderColor;
     }
 
+	public Transformation getSingleTransform() {
+		return mSingleTransform;
+	}
+
+	public Transformation getMultiTransform() {
+		return mMultiTransform;
+	}
+
     public static final class Builder {
         private int avatarBorderColor;
         private int avatarBackgroundColor;
         private int avatarTextColor;
         private Typeface avatarTextTypeface;
+		private Transformation singleTransform;
+		private Transformation multiTransform;
 
         public Builder() {
         }
@@ -64,6 +116,16 @@ public final class AvatarStyle {
             avatarBorderColor = val;
             return this;
         }
+
+		public Builder singleTransform(Transformation transformation) {
+			singleTransform = transformation;
+			return this;
+		}
+
+		public Builder multiTransform(Transformation transformation) {
+			multiTransform = transformation;
+			return this;
+		}
 
         public AvatarStyle build() {
             return new AvatarStyle(this);

--- a/layer-atlas/src/main/java/com/layer/atlas/util/AvatarStyle.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/AvatarStyle.java
@@ -13,54 +13,54 @@ public final class AvatarStyle {
     private int mAvatarBorderColor;
     private int mAvatarTextColor;
     private Typeface mAvatarTextTypeface;
-	private Transformation mSingleTransform;
-	private Transformation mMultiTransform;
+    private Transformation mSingleTransform;
+    private Transformation mMultiTransform;
 
     private AvatarStyle(Builder builder) {
         mAvatarBackgroundColor = builder.avatarBackgroundColor;
         mAvatarTextColor = builder.avatarTextColor;
         mAvatarTextTypeface = builder.avatarTextTypeface;
         mAvatarBorderColor = builder.avatarBorderColor;
-		mSingleTransform = builder.singleTransform;
-		mMultiTransform = builder.multiTransform;
+        mSingleTransform = builder.singleTransform;
+        mMultiTransform = builder.multiTransform;
     }
 
     public static AvatarStyle getDefaultStyle(Context context) {
-		TypedArray ta = context.getTheme().obtainStyledAttributes(null, R.styleable.AtlasConversationsRecyclerView,
-		R.attr.AtlasConversationsRecyclerView, 0);
-		AvatarStyle.Builder avatarStyleBuilder = new AvatarStyle.Builder();
-		avatarStyleBuilder.avatarTextColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarTextColor,
-		context.getResources().getColor(R.color.atlas_avatar_text)));
-		avatarStyleBuilder.avatarBackgroundColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarBackgroundColor,
-		context.getResources().getColor(R.color.atlas_avatar_background)));
-		avatarStyleBuilder.avatarBorderColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarBorderColor,
-		context.getResources().getColor(R.color.atlas_avatar_border)));
-		return avatarStyleBuilder.build();
-	}
+        TypedArray ta = context.getTheme().obtainStyledAttributes(null, R.styleable.AtlasConversationsRecyclerView,
+        R.attr.AtlasConversationsRecyclerView, 0);
+        AvatarStyle.Builder avatarStyleBuilder = new AvatarStyle.Builder();
+        avatarStyleBuilder.avatarTextColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarTextColor,
+        context.getResources().getColor(R.color.atlas_avatar_text)));
+        avatarStyleBuilder.avatarBackgroundColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarBackgroundColor,
+        context.getResources().getColor(R.color.atlas_avatar_background)));
+        avatarStyleBuilder.avatarBorderColor(ta.getColor(R.styleable.AtlasConversationsRecyclerView_avatarBorderColor,
+        context.getResources().getColor(R.color.atlas_avatar_border)));
+        return avatarStyleBuilder.build();
+    }
 
     public void setAvatarTextTypeface(Typeface avatarTextTypeface) {
         this.mAvatarTextTypeface = avatarTextTypeface;
     }
 
-	public void setAvatarBackgroundColor(int color) {
-		this.mAvatarBackgroundColor = color;
-	}
+    public void setAvatarBackgroundColor(int color) {
+        this.mAvatarBackgroundColor = color;
+    }
 
-	public void setAvatarTextColor(int color) {
-		this.mAvatarTextColor = color;
-	}
+    public void setAvatarTextColor(int color) {
+        this.mAvatarTextColor = color;
+    }
 
-	public void setAvatarBorderColor(int color) {
-		this.mAvatarBorderColor = color;
-	}
+    public void setAvatarBorderColor(int color) {
+        this.mAvatarBorderColor = color;
+    }
 
-	public void setSingleTransform(Transformation transform) {
-		this.mSingleTransform = transform;
-	}
+    public void setSingleTransform(Transformation transform) {
+        this.mSingleTransform = transform;
+    }
 
-	public void setMultiTransform(Transformation transform) {
-		this.mMultiTransform = transform;
-	}
+    public void setMultiTransform(Transformation transform) {
+        this.mMultiTransform = transform;
+    }
 
     public int getAvatarBackgroundColor() {
         return mAvatarBackgroundColor;
@@ -78,21 +78,21 @@ public final class AvatarStyle {
         return mAvatarBorderColor;
     }
 
-	public Transformation getSingleTransform() {
-		return mSingleTransform;
-	}
+    public Transformation getSingleTransform() {
+        return mSingleTransform;
+    }
 
-	public Transformation getMultiTransform() {
-		return mMultiTransform;
-	}
+    public Transformation getMultiTransform() {
+        return mMultiTransform;
+    }
 
     public static final class Builder {
         private int avatarBorderColor;
         private int avatarBackgroundColor;
         private int avatarTextColor;
         private Typeface avatarTextTypeface;
-		private Transformation singleTransform;
-		private Transformation multiTransform;
+        private Transformation singleTransform;
+        private Transformation multiTransform;
 
         public Builder() {
         }
@@ -117,15 +117,15 @@ public final class AvatarStyle {
             return this;
         }
 
-		public Builder singleTransform(Transformation transformation) {
-			singleTransform = transformation;
-			return this;
-		}
+        public Builder singleTransform(Transformation transformation) {
+            singleTransform = transformation;
+            return this;
+        }
 
-		public Builder multiTransform(Transformation transformation) {
-			multiTransform = transformation;
-			return this;
-		}
+        public Builder multiTransform(Transformation transformation) {
+            multiTransform = transformation;
+            return this;
+        }
 
         public AvatarStyle build() {
             return new AvatarStyle(this);

--- a/layer-atlas/src/main/java/com/layer/atlas/util/ConversationStyle.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/ConversationStyle.java
@@ -71,6 +71,10 @@ public final class ConversationStyle {
         this.mDateUnreadTextTypeface = dateUnreadTextTypeface;
     }
 
+	public void setAvatarStyle(AvatarStyle avatarStyle) {
+		mAvatarStyle = avatarStyle;
+	}
+
     @ColorInt
     public int getTitleTextColor() {
         return mTitleTextColor;

--- a/layer-atlas/src/main/java/com/layer/atlas/util/ConversationStyle.java
+++ b/layer-atlas/src/main/java/com/layer/atlas/util/ConversationStyle.java
@@ -71,9 +71,9 @@ public final class ConversationStyle {
         this.mDateUnreadTextTypeface = dateUnreadTextTypeface;
     }
 
-	public void setAvatarStyle(AvatarStyle avatarStyle) {
-		mAvatarStyle = avatarStyle;
-	}
+    public void setAvatarStyle(AvatarStyle avatarStyle) {
+        this.mAvatarStyle = avatarStyle;
+    }
 
     @ColorInt
     public int getTitleTextColor() {


### PR DESCRIPTION
This allows customization of all of the AvatarStyle properties, most notably the avatar image transformations.

The only customization added to the AtlasAvatar was for the avatar image transformations, including single and multiple avatar support.