### PR TITLE
AND-1262 - Keeping local state of the choice buttons

### DIFF
--- a/layer-atlas/src/main/java/com/layer/ui/message/MessageItemStatusViewModel.java
+++ b/layer-atlas/src/main/java/com/layer/ui/message/MessageItemStatusViewModel.java
@@ -61,6 +61,7 @@ public class MessageItemStatusViewModel extends ItemViewModel<Message> {
         if (!myMessage && mEnableReadReceipts) {
             message.markAsRead();
         }
+        notifyChange();
     }
 
     public void setEnableReadReceipts(boolean enableReadReceipts) {

--- a/layer-atlas/src/main/java/com/layer/ui/message/choice/ChoiceMessageMetadata.java
+++ b/layer-atlas/src/main/java/com/layer/ui/message/choice/ChoiceMessageMetadata.java
@@ -33,7 +33,7 @@ public class ChoiceMessageMetadata extends BaseObservable {
     @SerializedName("allow_reselect")
     private boolean mAllowReselect;
 
-    @SerializedName("allow_delselect")
+    @SerializedName("allow_deselect")
     private boolean mAllowDeselect;
 
     @SerializedName("allow_multiselect")

--- a/layer-atlas/src/main/java/com/layer/ui/message/response/ChoiceResponseModel.java
+++ b/layer-atlas/src/main/java/com/layer/ui/message/response/ChoiceResponseModel.java
@@ -3,7 +3,9 @@ package com.layer.ui.message.response;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -30,17 +32,18 @@ public class ChoiceResponseModel extends ResponseModel {
     }
 
     /**
-     * Add a choice to the participant data map
+     * Adds choices to the participant data map
      *
      * @param responseName key for the map entry
-     * @param choiceId value for the map entry
+     * @param choiceIds values for the map entry
      */
-    public void addChoice(@NonNull String responseName, @NonNull String choiceId) {
+    public void addChoices(@NonNull String responseName, @NonNull Collection<String> choiceIds) {
         Map<Object, Object> participantData = getParticipantData();
         if (participantData == null) {
             participantData = new HashMap<>(1);
             setParticipantData(participantData);
         }
-        participantData.put(responseName, choiceId);
+
+        participantData.put(responseName, TextUtils.join(",", choiceIds));
     }
 }

--- a/layer-atlas/src/main/res/color/ui_choice_button_selector.xml
+++ b/layer-atlas/src/main/res/color/ui_choice_button_selector.xml
@@ -2,6 +2,6 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="@color/ui_choice_button_text_enabled" android:state_enabled="true" android:state_pressed="false" android:state_selected="false"/>
     <item android:color="@color/ui_choice_button_text_disabled" android:state_enabled="false" android:state_selected="false"/>
-    <item android:color="@color/ui_choice_button_text_pressed" android:state_pressed="false"/>
-    <item android:color="@color/ui_choice_button_text_selected" android:state_pressed="false" android:state_selected="true"/>
+    <item android:color="@color/ui_choice_button_text_pressed" android:state_pressed="true"/>
+    <item android:color="@color/ui_choice_button_text_selected" android:state_selected="true"/>
 </selector>

--- a/layer-atlas/src/main/res/drawable/ui_choice_set_button_background_selector.xml
+++ b/layer-atlas/src/main/res/drawable/ui_choice_set_button_background_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/ui_choice_button_background_pressed" android:state_pressed="true"/>
-    <item android:drawable="@color/ui_choice_button_background_disabled" android:state_enabled="false"/>
+    <item android:drawable="@color/ui_choice_button_background_disabled" android:state_enabled="false" android:state_selected="false"/>
     <item android:drawable="@color/ui_choice_button_background_enabled" android:state_enabled="true" android:state_selected="false"/>
-    <item android:drawable="@color/ui_choice_button_background_selected" android:state_enabled="true" android:state_selected="true"/>
+    <item android:drawable="@color/ui_choice_button_background_selected" android:state_selected="true"/>
 </selector>

--- a/layer-atlas/src/main/res/layout/ui_choice_message_view.xml
+++ b/layer-atlas/src/main/res/layout/ui_choice_message_view.xml
@@ -14,6 +14,7 @@
 
     <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/choice_message_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
@@ -33,11 +34,10 @@
             android:textSize="@dimen/ui_choice_button_message_label_text_size"
             app:visibleOrGone="@{viewModel.hasContent &amp;&amp; viewModel.choiceMessageMetadata.label!=null}"/>
 
-        <LinearLayout
-            android:id="@+id/choice_buttons_parent"
+        <com.layer.ui.message.choice.ChoiceButtonSet
+            android:id="@+id/choice_button_set"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"/>
+            android:layout_height="wrap_content"/>
 
     </LinearLayout>
 </layout>

--- a/layer-atlas/src/main/res/values/ui-strings.xml
+++ b/layer-atlas/src/main/res/values/ui-strings.xml
@@ -82,7 +82,9 @@
 
     <string name="choice_message_model_default_title">Choose One</string>
 
-    <string name="response_message_status_text">%1$s selected \"%2$s\"</string>
-    <string name="response_message_status_text_with_label">%1$s selected \"%2$s\" for \"%3$s\"</string>
+    <string name="response_message_status_text_selected">%1$s selected \"%2$s\"</string>
+    <string name="response_message_status_text_with_label_selected">%1$s selected \"%2$s\" for \"%3$s\"</string>
+    <string name="response_message_status_text_deselected">%1$s deselected \"%2$s\"</string>
+    <string name="response_message_status_text_with_label_deselected">%1$s deselected \"%2$s\" for \"%3$s\"</string>
 
 </resources>


### PR DESCRIPTION
Fixing choice button set layout for choice messages. They denote a vertical layout with all choices in the set in it.
Fixing typo in choice metadata
Correctly handling button states for metadata flag
Notifying status view model of a change
Sending comma separated response representing full choice set